### PR TITLE
Move debugger UI to its own window

### DIFF
--- a/Sources/IosAnalyticsDebugger/AnalyticsDebugger.m
+++ b/Sources/IosAnalyticsDebugger/AnalyticsDebugger.m
@@ -127,7 +127,7 @@ NSString *currentSchemaId;
         CGRect screenRect = [[UIScreen mainScreen] bounds];
         debuggerWindow = [[PassthroughWindow alloc] init];
         debuggerWindow.frame = screenRect;
-        debuggerWindow.windowLevel = UIWindowLevelStatusBar;
+        debuggerWindow.windowLevel = UIWindowLevelAlert;
         debuggerWindow.backgroundColor = [UIColor clearColor];
         UIViewController *rootVC = [[PassthroughViewController alloc] init];
         [rootVC loadViewIfNeeded];

--- a/Sources/IosAnalyticsDebugger/PassthroughView.h
+++ b/Sources/IosAnalyticsDebugger/PassthroughView.h
@@ -1,0 +1,17 @@
+//
+//  PassthroughView.h
+//  
+//
+//  Created by Timothy Moose on 8/2/22.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A view that ignores touches on itself, but respects touches on subviews.
+@interface PassthroughView : UIView
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/IosAnalyticsDebugger/PassthroughView.m
+++ b/Sources/IosAnalyticsDebugger/PassthroughView.m
@@ -1,0 +1,15 @@
+//
+//  PassthroughView.m
+//  
+//
+//  Created by Timothy Moose on 8/2/22.
+//
+
+#import "PassthroughView.h"
+
+@implementation PassthroughView
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    UIView *view = [super hitTest:point withEvent:event];
+    return view == self ? nil : view;
+}
+@end

--- a/Sources/IosAnalyticsDebugger/PassthroughViewController.h
+++ b/Sources/IosAnalyticsDebugger/PassthroughViewController.h
@@ -1,0 +1,17 @@
+//
+//  PassthroughViewController.h
+//  
+//
+//  Created by Timothy Moose on 8/2/22.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A view controller that installs `PassthroughView` as it's root view.
+@interface PassthroughViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/IosAnalyticsDebugger/PassthroughViewController.m
+++ b/Sources/IosAnalyticsDebugger/PassthroughViewController.m
@@ -1,0 +1,19 @@
+//
+//  PassthroughViewController.m
+//  
+//
+//  Created by Timothy Moose on 8/2/22.
+//
+
+#import "PassthroughViewController.h"
+#import "PassthroughView.h"
+
+@interface PassthroughViewController ()
+
+@end
+
+@implementation PassthroughViewController
+- (void)loadView {
+    self.view = [[PassthroughView alloc] init];
+}
+@end

--- a/Sources/IosAnalyticsDebugger/PassthroughWindow.h
+++ b/Sources/IosAnalyticsDebugger/PassthroughWindow.h
@@ -1,0 +1,17 @@
+//
+//  PassthroughWindow.h
+//  
+//
+//  Created by Timothy Moose on 8/1/22.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A window that ignores touches on itself, but respects touches on subviews.
+@interface PassthroughWindow : UIWindow
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/IosAnalyticsDebugger/PassthroughWindow.m
+++ b/Sources/IosAnalyticsDebugger/PassthroughWindow.m
@@ -1,0 +1,19 @@
+//
+//  PassthroughWindow.m
+//  
+//
+//  Created by Timothy Moose on 8/1/22.
+//
+
+#import "PassthroughWindow.h"
+
+@interface PassthroughWindow ()
+@end
+
+@implementation PassthroughWindow
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    UIView *view = [super hitTest:point withEvent:event];
+    return view == self ? nil : view;
+}
+@end
+

--- a/Sources/IosAnalyticsDebugger/Resources/BarDebugger.xib
+++ b/Sources/IosAnalyticsDebugger/Resources/BarDebugger.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -94,8 +95,9 @@
                 <constraint firstItem="hmy-Gf-lbs" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="3k1-zj-n8k"/>
                 <constraint firstItem="8pX-Qi-zk8" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="Oa0-Ti-vCR"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="hmy-Gf-lbs" secondAttribute="trailing" id="OeS-jd-71c"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="hmy-Gf-lbs" secondAttribute="bottom" id="XN1-PQ-Blv"/>
+                <constraint firstAttribute="bottom" secondItem="hmy-Gf-lbs" secondAttribute="bottom" id="XN1-PQ-Blv"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="8pX-Qi-zk8" secondAttribute="trailing" id="lz9-j8-Arz"/>
+                <constraint firstItem="hmy-Gf-lbs" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" priority="750" id="pgA-tm-Uf9"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="153.62318840579712" y="269.19642857142856"/>

--- a/Sources/IosAnalyticsDebugger/Util.m
+++ b/Sources/IosAnalyticsDebugger/Util.m
@@ -27,23 +27,26 @@
 }
 
 + (NSInteger) barBottomOffset {
-    BOOL hasNotch = [self statusBarHeight] > 24.0;
-    
-    if (hasNotch) {
-        return 30;
+    if (@available(iOS 11.0, *)) {
+        return [UIApplication sharedApplication].keyWindow.safeAreaInsets.bottom;
     } else {
-        return 0;
+        BOOL hasNotch = [self statusBarHeight] > 24.0;
+        if (hasNotch) {
+            return 30;
+        } else {
+            return 0;
+        }
     }
 }
 
 + (CGFloat) statusBarHeight {
-    CGSize statusBarSize;
-    if (@available(iOS 13.0, *)) {
-        statusBarSize = [[[[UIApplication sharedApplication].keyWindow windowScene] statusBarManager] statusBarFrame].size;
+    if (@available(iOS 11.0, *)) {
+        return [UIApplication sharedApplication].keyWindow.safeAreaInsets.top;
     } else {
+        CGSize statusBarSize;
         statusBarSize = [[UIApplication sharedApplication] statusBarFrame].size;
+        return MIN(statusBarSize.width, statusBarSize.height);
     }
-    return MIN(statusBarSize.width, statusBarSize.height);
 }
 
 @end


### PR DESCRIPTION
This change moves the debugger UI into its own window above the app's main window, thereby keeping it on top even if the app presents modal view controllers.

1. The window is at the highest level, i.e. `UIWindowLevelAlert`.
1. The window and its root view controller ignore touches unless the user is touches the debugger UI, allowing all other touches to be delivered to the lower windows.
2. The window does not become the key window, preserving the current key window.
3. Fixes some minor UI layout issues (though the layout still gets in a bad state when the device is rotated).

https://user-images.githubusercontent.com/94019462/182450629-f6cfa083-c0bd-47a4-a62e-982545230bef.mp4


