### PR TITLE
Make EventsListScreenViewController accessible from outside of the module

### DIFF
--- a/Sources/IosAnalyticsDebugger/EventsListScreenViewController.m
+++ b/Sources/IosAnalyticsDebugger/EventsListScreenViewController.m
@@ -9,6 +9,7 @@
 #import "EventTableViewCell.h"
 #import "AnalyticsDebugger.h"
 #import "Util.h"
+#import "DebuggerEventItem.h"
 
 @interface EventsListScreenViewController ()
 @property (weak, nonatomic) IBOutlet UITextField *filterInput;
@@ -29,6 +30,13 @@
 
 NSLayoutConstraint * shownInputFieldConstraint;
 NSString * filter;
+
++ (instancetype)eventsListViewController {
+  NSBundle *resBundle = SWIFTPM_MODULE_BUNDLE;
+  
+  EventsListScreenViewController *eventsListViewController = [[EventsListScreenViewController alloc] initWithNibName:@"EventsListScreenViewController" bundle:resBundle];
+  return eventsListViewController;
+}
 
 - (void)onIputFilterTextChanged:(UITextField*)newFilterInput {
 

--- a/Sources/IosAnalyticsDebugger/include/EventsListScreenViewController.h
+++ b/Sources/IosAnalyticsDebugger/include/EventsListScreenViewController.h
@@ -6,14 +6,15 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "DebuggerEventItem.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class DebuggerEventItem;
 @interface EventsListScreenViewController : UIViewController <UITableViewDataSource, UITableViewDelegate>
 
 - (void) setExpendedStatus:(BOOL) expended forEvent:(DebuggerEventItem *) event;
 
++ (instancetype)eventsListViewController;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- Move `EventsListScreenViewController.h` to  `Sources/IosAnalyticsDebugger/include` to be able to access the class from outside of the module.
- Add a static method to get an instance of `EventsListScreenViewController`